### PR TITLE
Update pdsh to use all endpoints

### DIFF
--- a/manifests/generators.pp
+++ b/manifests/generators.pp
@@ -1,23 +1,25 @@
 class pdsh::generators (
   $puppetdb_host = 'puppetdb',
   $puppetdb_port = '8080',
-  $output_dir = '/etc/dsh/group',
-  $queries = {},
+  $output_dir    = '/etc/dsh/group',
+  $endpoint      = 'nodes',
+  $queries       = {},
   ) {
     #queries shoult be in the format:
-    #{label => label, query=> query}
+    #{label => label, endpoint => endpoint, query=> query}
     #provides the parameters to fill out the queries hash more
     $query_defaults = {
       puppetdb_host => $puppetdb_host ,
       puppetdb_port => $puppetdb_port,
       output_dir    => $output_dir,
+      endpoint      => $endpoint,
     }
 
     create_resources(pdsh_puppet_list,$queries,$query_defaults)
 }
 
 
-define pdsh_puppet_list($label,$puppetdb_host,$puppetdb_port,$output_dir,$query) {
+define pdsh_puppet_list($label,$puppetdb_host,$puppetdb_port,$output_dir,$endpoint,$query) {
   file {"/usr/local/sbin/pdsh_list_${label}.rb":
     content => template('pdsh/pdsh_list_generator.rb.erb'),
     mode    => '0744',

--- a/templates/pdsh_list_generator.rb.erb
+++ b/templates/pdsh_list_generator.rb.erb
@@ -6,11 +6,11 @@ require 'json'
 @puppetdb_port  = '<%= @puppetdb_port %>'
 @outputdir = '<%= @output_dir %>'
 @outputfile = '<%= @label%>'
-
+@endpoint = '<%= @endpoint %>'
 
 query = '<%= @query %>'
 
-curl_cmd = "curl -s -X POST http://#{@puppetdb_host}:#{@puppetdb_port}/pdb/query/v4/nodes -H 'Content-Type:application/json' -d '{\"query\":#{query}}'"
+curl_cmd = "curl -s -X POST http://#{@puppetdb_host}:#{@puppetdb_port}/pdb/query/v4/#{@endpoint} -H 'Content-Type:application/json' -d '{\"query\":#{query}}'"
 
 output = JSON.parse(`#{curl_cmd}`)
 


### PR DESCRIPTION
- Default to nodes endpoint, so that existing groups would still work
- can be overwritten by `endpoint` option under `pdsh::generators`